### PR TITLE
Use NPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
 	git clone https://github.com/Financial-Times/polyfill-service . && \
 	git checkout ${POLYFILL_TAG} && \
 	rm -rf .git && \
-	yarn install && \
+	npm ci && \
 	sed -i.bak -e 's,^node,exec node,' start_server.sh && \
 	mv start_server.sh /bin/ && \
 	chmod a+x /bin/start_server.sh && \


### PR DESCRIPTION
This switches to installing polyfill via NPM, because with NPM we get the benefit of the existing lockfile (and we also don't end up with the yarn cache polluting our image).