### PR TITLE
Upgrade our polyfill service to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:12-alpine
 RUN apk add --no-cache --update bash
 RUN apk add --no-cache --update --virtual build git python make gcc g++
 WORKDIR /polyfill
-ARG POLYFILL_TAG='v4.38.0'
+ARG POLYFILL_TAG='v4.49.4'
 ARG NODE_ENV='production'
 RUN \
 	git clone https://github.com/Financial-Times/polyfill-service . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-alpine
 
 RUN apk add --no-cache --update bash
-RUN apk add --no-cache --update --virtual build git python make gcc g++
+RUN apk add --no-cache --update --virtual build git python3 make gcc g++
 WORKDIR /polyfill
 ARG POLYFILL_TAG='v4.49.4'
 ARG NODE_ENV='production'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:16-alpine
 
 RUN apk add --no-cache --update bash
 RUN apk add --no-cache --update --virtual build git python make gcc g++


### PR DESCRIPTION
We want to update our polyfill docker image so that we get a more recent version of the IntersectionObserver polyfill for Safari.

This updates to the latest release from upstream: https://github.com/Financial-Times/polyfill-service/releases

CC @andyg0808

Ref: https://github.com/iFixit/ifixit/issues/41950